### PR TITLE
ナビゲーションの遷移をuidに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^6.0.1",
     "@mui/material": "^6.0.0-rc.0",
+    "jwt-decode": "^4.0.0",
     "next": "14.2.7",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,8 +19,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <AuthProvider>{children}</AuthProvider>
-        <BottomNavigation />
+        <AuthProvider>
+          <BottomNavigation />
+          {children}
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/components/layouts/bottomNavigation/index.tsx
+++ b/src/components/layouts/bottomNavigation/index.tsx
@@ -9,10 +9,12 @@ import AssignmentIcon from "@mui/icons-material/Assignment";
 import BookIcon from "@mui/icons-material/Book";
 import PersonIcon from "@mui/icons-material/Person";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/auth";
 
 export default function SimpleBottomNavigation() {
   const [value, setValue] = React.useState(0);
   const router = useRouter();
+  const { googleUserId } = useAuth();
 
   const handleNavigation = (newValue: number) => {
     setValue(newValue);
@@ -28,7 +30,9 @@ export default function SimpleBottomNavigation() {
         router.push("/guildCards/encyclopedias");
         break;
       case 3:
-        router.push("/profile");
+        if (googleUserId) {
+          router.push(`/profile/${googleUserId}`);
+        }
         break;
       default:
         break;
@@ -41,7 +45,7 @@ export default function SimpleBottomNavigation() {
         sx={{
           width: "100%",
           position: "fixed",
-          bottom: 0, 
+          bottom: 0,
           left: 0,
           right: 0,
           zIndex: 1000,

--- a/src/components/layouts/bottomNavigation/index.tsx
+++ b/src/components/layouts/bottomNavigation/index.tsx
@@ -55,7 +55,7 @@ export default function SimpleBottomNavigation() {
         <BottomNavigation
           showLabels
           value={value}
-          onChange={(event, newValue) => handleNavigation(newValue)}
+          onChange={(_event, newValue) => handleNavigation(newValue)}
         >
           <BottomNavigationAction label="ホーム" icon={<HomeIcon />} />
           <BottomNavigationAction label="クエスト" icon={<AssignmentIcon />} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,6 +2117,11 @@ json5@^1.0.2:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"


### PR DESCRIPTION
## 概要

下部ナビゲーションを押下した際の遷移先をユーザーごとの画面遷移に変更しました。

## 変更内容

- [jwt-decode](https://github.com/auth0/jwt-decode)をインストールしました。
- `<BottomNavigation />`を`<AuthProvider>`の中に移動し、使用配下にしました。
- src/contexts/auth/index.tsxでlocal strageからuidを取得するよりを追加しました。
- `<AuthProvider>`で取得したuidをsrc/components/layouts/bottomNavigation/index.tsxで取得し、ユーザーごとのページに遷移できるようにしました。

## 動作確認

- [x] 押下した際に(/profile/uid)もパスになっている

[![Image from Gyazo](https://i.gyazo.com/e6944c7f7c87d8624df3bb2d15434f59.jpg)](https://gyazo.com/e6944c7f7c87d8624df3bb2d15434f59)