### PR TITLE
クエスト一覧ページのレイアウトを修正しました

### DIFF
--- a/src/app/(auth)/quests/page.tsx
+++ b/src/app/(auth)/quests/page.tsx
@@ -1,17 +1,9 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { BasicButton } from "@/components/layouts";
-import Dialog from "@mui/material/Dialog";
-import DialogTitle from "@mui/material/DialogTitle";
-import DialogContent from "@mui/material/DialogContent";
-import IconButton from "@mui/material/IconButton";
-import CloseIcon from "@mui/icons-material/Close";
-import Link from "next/link";
-import { SuccessMessage } from "@/components/layouts/messages";
-import styled from "@emotion/styled";
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { GameContainerWrapper, QuestBoard, QuestDetail, MobileDialog } from '@/features/quests';
+import { SuccessMessage } from '@/components/layouts/messages';
 
 interface Quest {
   id: number;
@@ -20,67 +12,21 @@ interface Quest {
 }
 
 const quests: Quest[] = [
-  { id: 1, title: "泥土の隠者", monsterName: "ドロドロン" },
-  { id: 2, title: "彷徨える雪鬼獣", monsterName: "ユキオニ" },
-  { id: 3, title: "轟く声", monsterName: "ゴウゴウザウルス" },
-  { id: 4, title: "ねじれた欲望", monsterName: "ネジレッド" },
-  { id: 5, title: "大社跡での肝試し", monsterName: "ヒミツノヨウカイ" },
+  { id: 1, title: '泥土の隠者', monsterName: 'ドロドロン' },
+  { id: 2, title: '彷徨える雪鬼獣', monsterName: 'ユキオニ' },
+  { id: 3, title: '轟く声', monsterName: 'ゴウゴウザウルス' },
+  { id: 4, title: 'ねじれた欲望', monsterName: 'ネジレッド' },
+  { id: 5, title: '大社跡での肝試し', monsterName: 'ヒミツノヨウカイ' },
 ];
 
-const monsterImage = "/images/monsters/encyclopedias/monster_question_mark.jpg";
-
-const GameContainer = styled.div`
-  background-image: url('/images/layouts/basic_background.jpg');
-  background-repeat: repeat;
-  background-size: auto;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  color: #fff;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-`;
-
-const QuestBoard = styled.div`
-  background-color: rgba(30, 58, 138, 0.8);
-  border: 3px solid #C0C0C0;
-  border-radius: 15px;
-  padding: 20px;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
-`;
-
-const QuestItem = styled.li<{ isSelected: boolean }>`
-  background-color: ${props => props.isSelected ? "#3B82F6" : "#1E3A8A"};
-  padding: 10px;
-  margin-bottom: 10px;
-  border-radius: 5px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-
-  &:hover {
-    background-color: #3B82F6;
-    transform: scale(1.05);
-  }
-`;
-
-const QuestDetailContainer = styled.div`
-  background-color: rgba(30, 58, 138, 0.8);
-  border: 3px solid #C0C0C0;
-  border-radius: 15px;
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
-`;
+const monsterImage = '/images/monsters/encyclopedias/monster_question_mark.jpg';
 
 export default function QuestPage() {
   const [selectedQuest, setSelectedQuest] = useState<Quest | null>(quests[0]);
   const [open, setOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
-  const [successMessage, setSuccessMessage] = useState("");
+  const [successMessage, setSuccessMessage] = useState('');
   const router = useRouter();
 
   useEffect(() => {
@@ -89,19 +35,19 @@ export default function QuestPage() {
     };
 
     handleResize();
-    window.addEventListener("resize", handleResize);
+    window.addEventListener('resize', handleResize);
 
     return () => {
-      window.removeEventListener("resize", handleResize);
+      window.removeEventListener('resize', handleResize);
     };
   }, []);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
-    const token = urlParams.get("token");
+    const token = urlParams.get('token');
 
     if (token) {
-      setSuccessMessage("ログインしました！");
+      setSuccessMessage('ログインしました！');
       setShowSuccessMessage(true);
     }
   }, []);
@@ -120,97 +66,32 @@ export default function QuestPage() {
   };
 
   return (
-    <GameContainer>
+    <GameContainerWrapper>
       {showSuccessMessage && (
-        <SuccessMessage
-          message={successMessage}
-          onClose={() => setShowSuccessMessage(false)}
-        />
+        <SuccessMessage message={successMessage} onClose={() => setShowSuccessMessage(false)} />
       )}
       <div className="w-full max-w-6xl pt-4 px-4">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <QuestBoard className="md:col-span-1">
-            <h6 className="text-center text-2xl font-bold mb-6">
-              クエスト掲示板
-            </h6>
-            <ul>
-              {quests.map((quest) => (
-                <QuestItem
-                  key={quest.id}
-                  onClick={() => handleQuestClick(quest)}
-                  isSelected={selectedQuest?.id === quest.id}
-                >
-                  {quest.title} - {quest.monsterName}
-                </QuestItem>
-              ))}
-            </ul>
-          </QuestBoard>
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_2fr] gap-4">
+          <QuestBoard
+            quests={quests}
+            selectedQuestId={selectedQuest?.id || null}
+            onQuestClick={handleQuestClick}
+          />
 
           {!isMobile && selectedQuest && (
-            <QuestDetailContainer className="md:col-span-2">
-              <h6 className="text-2xl font-bold mb-6">
-                {selectedQuest.title}
-              </h6>
-              <Image
-                src={monsterImage}
-                alt={selectedQuest.monsterName}
-                width={250}
-                height={250}
-                className="mb-6 border-4 border-gray-300 rounded-lg"
-              />
-              <p className="text-center mb-6 text-xl">
-                {`目標: ${selectedQuest.monsterName} 1頭の狩猟`}
-              </p>
-              <Link href={`/quests/${selectedQuest.id}/battleStart`}>
-                <BasicButton text="クエスト出発" />
-              </Link>
-            </QuestDetailContainer>
+            <QuestDetail quest={selectedQuest} monsterImage={monsterImage} />
           )}
         </div>
       </div>
 
-      {isMobile && open && (
-        <Dialog
+      {isMobile && selectedQuest && (
+        <MobileDialog
           open={open}
           onClose={() => setOpen(false)}
-          fullWidth
-          maxWidth="sm"
-          PaperProps={{
-            style: {
-              backgroundColor: 'rgba(30, 58, 138, 0.9)',
-              border: '3px solid #C0C0C0',
-              borderRadius: '15px',
-              color: '#fff',
-            },
-          }}
-        >
-          <DialogTitle>
-            {selectedQuest?.title}
-            <IconButton
-              aria-label="close"
-              onClick={() => setOpen(false)}
-              className="absolute top-2 right-2 text-gray-300 hover:text-white"
-            >
-              <CloseIcon />
-            </IconButton>
-          </DialogTitle>
-          <DialogContent dividers className="text-center">
-            <Image
-              src={monsterImage}
-              alt={selectedQuest?.monsterName || "モンスター"}
-              width={200}
-              height={200}
-              className="mb-6 mx-auto border-4 border-gray-300 rounded-lg"
-            />
-            <p className="mb-6 text-xl">
-              {selectedQuest && `目標: ${selectedQuest.monsterName} 1頭の狩猟`}
-            </p>
-            <Link href={`/quests/${selectedQuest?.id}/battleStart`}>
-              <BasicButton text="クエスト出発" />
-            </Link>
-          </DialogContent>
-        </Dialog>
+          quest={selectedQuest}
+          monsterImage={monsterImage}
+        />
       )}
-    </GameContainer>
+    </GameContainerWrapper>
   );
 }

--- a/src/app/(auth)/quests/page.tsx
+++ b/src/app/(auth)/quests/page.tsx
@@ -11,23 +11,69 @@ import IconButton from "@mui/material/IconButton";
 import CloseIcon from "@mui/icons-material/Close";
 import Link from "next/link";
 import { SuccessMessage } from "@/components/layouts/messages";
+import styled from "@emotion/styled";
 
 interface Quest {
   id: number;
   title: string;
+  monsterName: string;
 }
 
 const quests: Quest[] = [
-  { id: 1, title: "泥土の隠者" },
-  { id: 2, title: "彷徨える雪鬼獣" },
-  { id: 3, title: "轟く声" },
-  { id: 4, title: "ねじれた欲望" },
-  { id: 5, title: "大社跡での肝試し" },
-  { id: 6, title: "電光雷轟、夢幻泡影" },
-  { id: 7, title: "天空の王者、大地の暴君" },
+  { id: 1, title: "泥土の隠者", monsterName: "ドロドロン" },
+  { id: 2, title: "彷徨える雪鬼獣", monsterName: "ユキオニ" },
+  { id: 3, title: "轟く声", monsterName: "ゴウゴウザウルス" },
+  { id: 4, title: "ねじれた欲望", monsterName: "ネジレッド" },
+  { id: 5, title: "大社跡での肝試し", monsterName: "ヒミツノヨウカイ" },
 ];
 
 const monsterImage = "/images/monsters/encyclopedias/monster_question_mark.jpg";
+
+const GameContainer = styled.div`
+  background-image: url('/images/layouts/basic_background.jpg');
+  background-repeat: repeat;
+  background-size: auto;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+`;
+
+const QuestBoard = styled.div`
+  background-color: rgba(30, 58, 138, 0.8);
+  border: 3px solid #C0C0C0;
+  border-radius: 15px;
+  padding: 20px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
+`;
+
+const QuestItem = styled.li<{ isSelected: boolean }>`
+  background-color: ${props => props.isSelected ? "#3B82F6" : "#1E3A8A"};
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+
+  &:hover {
+    background-color: #3B82F6;
+    transform: scale(1.05);
+  }
+`;
+
+const QuestDetailContainer = styled.div`
+  background-color: rgba(30, 58, 138, 0.8);
+  border: 3px solid #C0C0C0;
+  border-radius: 15px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
+`;
 
 export default function QuestPage() {
   const [selectedQuest, setSelectedQuest] = useState<Quest | null>(quests[0]);
@@ -42,7 +88,6 @@ export default function QuestPage() {
       setIsMobile(window.innerWidth <= 600);
     };
 
-    // 初回レンダリング時とリサイズ時にデバイスのサイズをチェック
     handleResize();
     window.addEventListener("resize", handleResize);
 
@@ -75,7 +120,7 @@ export default function QuestPage() {
   };
 
   return (
-    <div className="relative min-h-screen bg-[url('/images/layouts/basic_background.jpg')] bg-repeat bg-auto flex flex-col justify-center items-center">
+    <GameContainer>
       {showSuccessMessage && (
         <SuccessMessage
           message={successMessage}
@@ -84,82 +129,81 @@ export default function QuestPage() {
       )}
       <div className="w-full max-w-6xl pt-4 px-4">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {/* クエスト一覧 */}
-          <div className="bg-gray-700 text-white p-4 rounded-lg md:col-span-1">
-            <h6 className="text-center text-lg font-semibold mb-4">
-              クエスト一覧
+          <QuestBoard className="md:col-span-1">
+            <h6 className="text-center text-2xl font-bold mb-6">
+              クエスト掲示板
             </h6>
             <ul>
               {quests.map((quest) => (
-                <li
+                <QuestItem
                   key={quest.id}
                   onClick={() => handleQuestClick(quest)}
-                  className={`p-2 mb-2 rounded cursor-pointer ${
-                    selectedQuest?.id === quest.id
-                      ? "bg-gray-600"
-                      : "bg-gray-700"
-                  } hover:bg-gray-600`}
+                  isSelected={selectedQuest?.id === quest.id}
                 >
-                  {quest.title}
-                </li>
+                  {quest.title} - {quest.monsterName}
+                </QuestItem>
               ))}
             </ul>
-          </div>
+          </QuestBoard>
 
-          {/* クエスト詳細 (PC画面時に表示) */}
           {!isMobile && selectedQuest && (
-            <div className="md:col-span-2 bg-gray-700 text-white p-4 rounded-lg flex flex-col items-center">
-              <h6 className="text-lg font-semibold mb-4">
+            <QuestDetailContainer className="md:col-span-2">
+              <h6 className="text-2xl font-bold mb-6">
                 {selectedQuest.title}
               </h6>
-              {/* モンスターの画像 */}
               <Image
                 src={monsterImage}
-                alt={selectedQuest.title}
-                width={200}
-                height={200}
-                className="mb-4"
+                alt={selectedQuest.monsterName}
+                width={250}
+                height={250}
+                className="mb-6 border-4 border-gray-300 rounded-lg"
               />
-              <p className="text-center mb-4">
-                {`${selectedQuest.title} 1頭の狩猟`}
+              <p className="text-center mb-6 text-xl">
+                {`目標: ${selectedQuest.monsterName} 1頭の狩猟`}
               </p>
               <Link href={`/quests/${selectedQuest.id}/battleStart`}>
                 <BasicButton text="クエスト出発" />
               </Link>
-            </div>
+            </QuestDetailContainer>
           )}
         </div>
       </div>
 
-      {/* モバイル版モーダル */}
       {isMobile && open && (
         <Dialog
           open={open}
           onClose={() => setOpen(false)}
           fullWidth
           maxWidth="sm"
+          PaperProps={{
+            style: {
+              backgroundColor: 'rgba(30, 58, 138, 0.9)',
+              border: '3px solid #C0C0C0',
+              borderRadius: '15px',
+              color: '#fff',
+            },
+          }}
         >
           <DialogTitle>
             {selectedQuest?.title}
             <IconButton
               aria-label="close"
               onClick={() => setOpen(false)}
-              className="absolute top-2 right-2 text-gray-600 hover:text-gray-900"
+              className="absolute top-2 right-2 text-gray-300 hover:text-white"
             >
               <CloseIcon />
             </IconButton>
           </DialogTitle>
           <DialogContent dividers className="text-center">
-            {/* モンスターの画像（モバイル版） */}
             <Image
               src={monsterImage}
-              alt={selectedQuest?.title || "モンスター"}
-              width={150}
-              height={150}
-              className="mb-4 mx-auto"
+              alt={selectedQuest?.monsterName || "モンスター"}
+              width={200}
+              height={200}
+              className="mb-6 mx-auto border-4 border-gray-300 rounded-lg"
             />
-            <p className="mb-4">
-              {selectedQuest && `${selectedQuest.title} 1頭の狩猟`}
+            <p className="mb-6 text-xl">
+              {selectedQuest && `目標: ${selectedQuest.monsterName} 1頭の狩猟`}
             </p>
             <Link href={`/quests/${selectedQuest?.id}/battleStart`}>
               <BasicButton text="クエスト出発" />
@@ -167,6 +211,6 @@ export default function QuestPage() {
           </DialogContent>
         </Dialog>
       )}
-    </div>
+    </GameContainer>
   );
 }

--- a/src/features/quests/gameContainerWrapper/index.tsx
+++ b/src/features/quests/gameContainerWrapper/index.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+export const GameContainerWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return <GameContainer>{children}</GameContainer>;
+};
+
+const GameContainer = styled.div`
+  background-image: url('/images/layouts/basic_background.jpg');
+  background-repeat: repeat;
+  background-size: auto;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+`;
+
+export default GameContainerWrapper;

--- a/src/features/quests/index.js
+++ b/src/features/quests/index.js
@@ -1,0 +1,13 @@
+import GameContainerWrapper from "./gameContainerWrapper";
+import MobileDialog from "./mobileDialog";
+import QuestBoard from "./questBoard";
+import QuestDetail from "./questDetail";
+import QuestItem from "./questItem";
+
+export {
+  GameContainerWrapper,
+  MobileDialog,
+  QuestBoard,
+  QuestDetail,
+  QuestItem,
+};

--- a/src/features/quests/mobileDialog/index.tsx
+++ b/src/features/quests/mobileDialog/index.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+import Image from 'next/image';
+import Link from 'next/link';
+import { BasicButton } from '@/components/layouts';
+import styled from '@emotion/styled';
+
+interface MobileDialogProps {
+  open: boolean;
+  onClose: () => void;
+  quest: {
+    id: number;
+    title: string;
+    monsterName: string;
+  };
+  monsterImage: string;
+}
+
+const StyledDialogTitle = styled(DialogTitle)`
+  border-bottom: 2px solid #ffffff;
+  padding-bottom: 10px;
+  margin-bottom: 20px;
+`;
+
+const StyledMonsterName = styled.p`
+  font-size: 1.5rem;
+  font-weight: bold;
+  text-align: center;
+  padding-bottom: 10px;
+  margin-bottom: 20px;
+`;
+
+const MobileDialog: React.FC<MobileDialogProps> = ({ open, onClose, quest, monsterImage }) => {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{
+        style: {
+          backgroundColor: 'rgba(30, 58, 138, 0.9)',
+          color: '#fff',
+          borderRadius: '15px',
+          padding: '20px',
+        },
+      }}
+    >
+      <StyledDialogTitle>
+        {quest.title}
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-300 hover:text-white"
+        >
+          <CloseIcon />
+        </IconButton>
+      </StyledDialogTitle>
+      <DialogContent dividers className="text-center">
+        <Image
+          src={monsterImage}
+          alt={quest.monsterName}
+          width={200}
+          height={200}
+          className="mb-6 mx-auto border-4 border-gray-300 rounded-lg"
+        />
+        <StyledMonsterName>
+         {quest.monsterName} 1頭の狩猟k
+        </StyledMonsterName>
+        <Link href={`/quests/${quest.id}/battleStart`}>
+          <BasicButton text="クエスト出発" />
+        </Link>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MobileDialog;

--- a/src/features/quests/questBoard/index.tsx
+++ b/src/features/quests/questBoard/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { QuestItem } from "@/features/quests";
+
+interface Quest {
+  id: number;
+  title: string;
+  monsterName: string;
+}
+
+interface QuestBoardProps {
+  quests: Quest[];
+  selectedQuestId: number | null;
+  onQuestClick: (quest: Quest) => void;
+}
+
+const QuestBoardContainer = styled.div`
+  background-color: rgba(30, 58, 138, 0.8);
+  border: 3px solid #C0C0C0;
+  border-radius: 15px;
+  padding: 20px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
+`;
+
+const TitleContainer = styled.div`
+  width: 100%;
+  border-bottom: 2px solid #fff;
+  text-align: center;
+  margin-bottom: 20px;
+`;
+
+const Title = styled.h6`
+  font-size: 1.5rem;
+  font-weight: bold;
+  padding-bottom: 10px;
+`;
+
+const QuestBoard: React.FC<QuestBoardProps> = ({ quests, selectedQuestId, onQuestClick }) => {
+  return (
+    <QuestBoardContainer>
+      <TitleContainer>
+        <Title>クエスト掲示板</Title>
+      </TitleContainer>
+      <ul>
+        {quests.map((quest) => (
+          <QuestItem
+            key={quest.id}
+            quest={quest}
+            isSelected={selectedQuestId === quest.id}
+            onClick={() => onQuestClick(quest)}
+          />
+        ))}
+      </ul>
+    </QuestBoardContainer>
+  );
+};
+
+export default QuestBoard;

--- a/src/features/quests/questDetail/index.tsx
+++ b/src/features/quests/questDetail/index.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import styled from "@emotion/styled";
+import Image from "next/image";
+import Link from "next/link";
+import { BasicButton } from "@/components/layouts";
+
+interface QuestDetailProps {
+  quest: {
+    id: number;
+    title: string;
+    monsterName: string;
+  };
+  monsterImage: string;
+}
+
+const QuestDetailContainer = styled.div`
+  background-color: rgba(30, 58, 138, 0.8);
+  border: 3px solid #c0c0c0;
+  border-radius: 15px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
+  width: 100%;
+`;
+
+const TitleContainer = styled.div`
+  width: 100%;
+  border-bottom: 2px solid #fff;
+  text-align: center;
+  margin-bottom: 20px;
+`;
+
+const Title = styled.h6`
+  font-size: 1.5rem;
+  font-weight: bold;
+  padding-bottom: 10px;
+`;
+
+const QuestDetail: React.FC<QuestDetailProps> = ({ quest, monsterImage }) => {
+  return (
+    <QuestDetailContainer>
+      <TitleContainer>
+        <Title>{quest.title}</Title>
+      </TitleContainer>
+      <Image
+        src={monsterImage}
+        alt={quest.monsterName}
+        width={250}
+        height={250}
+        className="mb-6 border-4 border-gray-300 rounded-lg"
+      />
+      <p className="text-center mb-6 text-xl">
+        {quest.monsterName} 1頭の狩猟
+      </p>
+      <Link href={`/quests/${quest.id}/battleStart`}>
+        <BasicButton text="クエスト出発" />
+      </Link>
+    </QuestDetailContainer>
+  );
+};
+
+export default QuestDetail;

--- a/src/features/quests/questItem/index.tsx
+++ b/src/features/quests/questItem/index.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+interface Quest {
+  id: number;
+  title: string;
+  monsterName: string;
+}
+
+interface QuestItemProps {
+  quest: Quest;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+const Item = styled.li<{ isSelected: boolean }>`
+  background-color: ${(props) => (props.isSelected ? "#3B82F6" : "#1E3A8A")};
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+
+  &:hover {
+    background-color: #3b82f6;
+    transform: scale(1.05);
+  }
+`;
+
+const QuestItem: React.FC<QuestItemProps> = ({
+  quest,
+  isSelected,
+  onClick,
+}) => {
+  return (
+    <Item isSelected={isSelected} onClick={onClick}>
+      {quest.title}
+    </Item>
+  );
+};
+
+export default QuestItem;


### PR DESCRIPTION
## 概要

クエスト一覧ページを本アプリのテーマカラーに合わせてレイアウトを変更しました。
コンポーネントに切り分けてどこでなんの処理をしているのか明確にしました。

## 変更内容

- レイアウトを本アプリのテーマカラーに合わせて変更しました
- クエスト一覧,クエスト詳細/(PC版+スマホ版)のコンポーネント作成
- スマホ画面の際の質問詳細モーダルのコンポーネント化

## 動作確認

| PC | IPadなど | スマホ,モーダル |
| ---- | ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/b6fd1dbbe3494f07644312e43f9ef3d0.jpg)](https://gyazo.com/b6fd1dbbe3494f07644312e43f9ef3d0) | [![Image from Gyazo](https://i.gyazo.com/7188d58d357cf9a66a53d8a8d2bc63ee.jpg)](https://gyazo.com/7188d58d357cf9a66a53d8a8d2bc63ee) | [![Image from Gyazo](https://i.gyazo.com/034e5ddb9f8d4e807e2427a7f486b8ae.jpg)](https://gyazo.com/034e5ddb9f8d4e807e2427a7f486b8ae)[![Image from Gyazo](https://i.gyazo.com/5fc7ad6af0c00553df9ce0d9b7a333c0.jpg)](https://gyazo.com/5fc7ad6af0c00553df9ce0d9b7a333c0) |

