### PR TITLE
profileページのリファクタリング

### DIFF
--- a/src/lib/fetcher/index.tsx
+++ b/src/lib/fetcher/index.tsx
@@ -1,20 +1,30 @@
-const fetcher = async (url: string): Promise<any> => {
+const fetcher = async (
+  url: string,
+  method: "GET" | "PATCH" = "GET",
+  data?: any
+): Promise<any> => {
   const token = localStorage.getItem("authToken");
 
   if (!token) {
     throw new Error("認証トークンがありません。");
   }
 
-  const response = await fetch(url, {
-    method: "GET",
+  const options: RequestInit = {
+    method,
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-  });
+  };
+
+  if (method === "PATCH" && data) {
+    options.body = JSON.stringify(data);
+  }
+
+  const response = await fetch(url, options);
 
   if (!response.ok) {
-    throw new Error("データの取得に失敗しました");
+    throw new Error(`${method}リクエストの実行に失敗しました`);
   }
 
   return response.json();


### PR DESCRIPTION
## 概要

プロフィールページのリファクタリングを行いました。

## 変更内容

- authからtokenを取得している箇所を`useFetchData`をimportし取得する形にしました。
- src/lib/fetcher/index.tsxに新たに`PATCH`の処理を追加し、fetcherを呼び出すことで他の箇所でも使用できる価値にしました。

## 動作確認

- [x] プロフィールの挙動に変わりないか
- [x] クエスト一覧の共同に変わりないか