### PR TITLE
クエスト一覧ページのfetch方法変更

### DIFF
--- a/src/app/(auth)/quests/page.tsx
+++ b/src/app/(auth)/quests/page.tsx
@@ -11,19 +11,7 @@ import { SuccessMessage } from "@/components/layouts/messages";
 import useFetchData from "@/lib/useFetchData";
 import { Settings } from "@/config";
 import { Loading } from "@/components/layouts";
-
-interface Quest {
-  id: number;
-  title: string;
-  monster_id: number;
-  monsterName: string;
-}
-
-interface Monster {
-  id: number;
-  name: string;
-  bestiary_monster_image_url: string;
-}
+import { Quest, Monster } from "@/types";
 
 export default function QuestPage() {
   const [selectedQuestId, setSelectedQuestId] = useState<number>(1);

--- a/src/app/(auth)/quests/page.tsx
+++ b/src/app/(auth)/quests/page.tsx
@@ -8,6 +8,22 @@ import {
   MobileDialog,
 } from "@/features/quests";
 import { SuccessMessage } from "@/components/layouts/messages";
+import useFetchData from "@/lib/useFetchData";
+import { Settings } from "@/config";
+import { Loading } from "@/components/layouts";
+
+interface Quest {
+  id: number;
+  title: string;
+  monster_id: number;
+  monsterName: string;
+}
+
+interface Monster {
+  id: number;
+  name: string;
+  bestiary_monster_image_url: string;
+}
 
 export default function QuestPage() {
   const [selectedQuestId, setSelectedQuestId] = useState<number>(1);
@@ -15,6 +31,11 @@ export default function QuestPage() {
   const [isMobile, setIsMobile] = useState(false);
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
+
+  const quests = useFetchData<Quest[]>(`${Settings.API_URL}/api/v1/quests`);
+  const monsters = useFetchData<Monster[]>(
+    `${Settings.API_URL}/api/v1/monsters`
+  );
 
   useEffect(() => {
     const handleResize = () => {
@@ -46,6 +67,10 @@ export default function QuestPage() {
     }
   };
 
+  if (!quests || !monsters) {
+    return <Loading />;
+  }
+
   return (
     <GameContainerWrapper>
       {/* 成功メッセージの表示 */}
@@ -59,11 +84,21 @@ export default function QuestPage() {
       {/* レイアウト */}
       <div className="w-full max-w-6xl pt-4 px-4">
         <div className="grid grid-cols-1 md:grid-cols-[1fr_2fr] gap-4">
-          {/* QuestBoardにisMobileを渡す */}
-          <QuestBoard onQuestClick={handleQuestClick} isMobile={isMobile} />
+          {/* QuestBoardにクエストデータを渡す */}
+          <QuestBoard
+            quests={quests}
+            onQuestClick={handleQuestClick}
+            isMobile={isMobile}
+          />
 
           {/* スマホではない場合はQuestDetailを表示 */}
-          {!isMobile && <QuestDetail questId={selectedQuestId} />}
+          {!isMobile && (
+            <QuestDetail
+              questId={selectedQuestId}
+              quest={quests.find((q) => q.id === selectedQuestId)}
+              monster={monsters.find((m) => m.id === selectedQuestId)}
+            />
+          )}
         </div>
       </div>
 
@@ -73,6 +108,8 @@ export default function QuestPage() {
           open={open}
           onClose={() => setOpen(false)}
           questId={selectedQuestId}
+          quest={quests.find((q) => q.id === selectedQuestId)}
+          monster={monsters.find((m) => m.id === selectedQuestId)}
         />
       )}
     </GameContainerWrapper>

--- a/src/features/quests/mobileDialog/index.tsx
+++ b/src/features/quests/mobileDialog/index.tsx
@@ -10,6 +10,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { BasicButton, Loading } from "@/components/layouts";
 import styled from "@emotion/styled";
+import { Quest, Monster } from "@/types";
 
 interface MobileDialogProps {
   open: boolean;
@@ -17,18 +18,6 @@ interface MobileDialogProps {
   questId: number;
   quest: Quest | undefined;
   monster: Monster | undefined;
-}
-
-interface Quest {
-  id: number;
-  title: string;
-  monster_id: number;
-}
-
-interface Monster {
-  id: number;
-  name: string;
-  bestiary_monster_image_url: string;
 }
 
 const StyledDialogTitle = styled(DialogTitle)`

--- a/src/features/quests/mobileDialog/index.tsx
+++ b/src/features/quests/mobileDialog/index.tsx
@@ -10,13 +10,13 @@ import Image from "next/image";
 import Link from "next/link";
 import { BasicButton, Loading } from "@/components/layouts";
 import styled from "@emotion/styled";
-import useFetchData from "@/lib/useFetchData";
-import { Settings } from "@/config";
 
 interface MobileDialogProps {
   open: boolean;
   onClose: () => void;
   questId: number;
+  quest: Quest | undefined;
+  monster: Monster | undefined;
 }
 
 interface Quest {
@@ -67,15 +67,9 @@ const CloseButton = styled(IconButton)`
 const MobileDialog: React.FC<MobileDialogProps> = ({
   open,
   onClose,
-  questId,
+  quest,
+  monster,
 }) => {
-  const quest = useFetchData<Quest>(
-    `${Settings.API_URL}/api/v1/quests/${questId}`
-  );
-  const monster = useFetchData<Monster>(
-    quest ? `${Settings.API_URL}/api/v1/monsters/${questId}` : ""
-  );
-
   if (!quest || !monster) {
     return <Loading />;
   }

--- a/src/features/quests/questBoard/index.tsx
+++ b/src/features/quests/questBoard/index.tsx
@@ -4,12 +4,7 @@ import React, { useState } from "react";
 import styled from "@emotion/styled";
 import { QuestItem } from "@/features/quests";
 import { Loading } from "@/components/layouts";
-
-interface Quest {
-  id: number;
-  title: string;
-  monsterName: string;
-}
+import { Quest } from "@/types";
 
 interface QuestBoardProps {
   quests: Quest[];

--- a/src/features/quests/questBoard/index.tsx
+++ b/src/features/quests/questBoard/index.tsx
@@ -4,8 +4,6 @@ import React, { useState } from "react";
 import styled from "@emotion/styled";
 import { QuestItem } from "@/features/quests";
 import { Loading } from "@/components/layouts";
-import useFetchData from "@/lib/useFetchData";
-import { Settings } from "@/config";
 
 interface Quest {
   id: number;
@@ -14,6 +12,7 @@ interface Quest {
 }
 
 interface QuestBoardProps {
+  quests: Quest[];
   onQuestClick: (questId: number) => void;
   isMobile: boolean;
 }
@@ -48,12 +47,7 @@ const ListItem = styled.li`
   margin-bottom: 10px;
 `;
 
-interface QuestBoardProps {
-  onQuestClick: (questId: number) => void;
-}
-
-const QuestBoard: React.FC<QuestBoardProps> = ({ onQuestClick }) => {
-  const quests = useFetchData<Quest[]>(`${Settings.API_URL}/api/v1/quests`);
+const QuestBoard: React.FC<QuestBoardProps> = ({ quests, onQuestClick }) => {
   const [selectedQuestId, setSelectedQuestId] = useState<number | null>(null);
 
   if (!quests) {

--- a/src/features/quests/questDetail/index.tsx
+++ b/src/features/quests/questDetail/index.tsx
@@ -4,11 +4,11 @@ import styled from "@emotion/styled";
 import Image from "next/image";
 import Link from "next/link";
 import { BasicButton, Loading } from "@/components/layouts";
-import useFetchData from "@/lib/useFetchData";
-import { Settings } from "@/config";
 
 interface QuestDetailProps {
   questId: number;
+  quest: Quest | undefined;
+  monster: Monster | undefined;
 }
 
 interface Quest {
@@ -62,12 +62,7 @@ const ButtonContainer = styled.div`
   margin-top: 20px;
 `;
 
-const QuestDetail: React.FC<QuestDetailProps> = ({ questId }) => {
-  const quest = useFetchData<Quest>(`${Settings.API_URL}/api/v1/quests/${questId}`);
-  const monster = useFetchData<Monster>(
-    quest ? `${Settings.API_URL}/api/v1/monsters/${questId}` : ""
-  );
-
+const QuestDetail: React.FC<QuestDetailProps> = ({ quest, monster }) => {
   if (!quest || !monster) {
     return <Loading />;
   }

--- a/src/features/quests/questDetail/index.tsx
+++ b/src/features/quests/questDetail/index.tsx
@@ -4,23 +4,12 @@ import styled from "@emotion/styled";
 import Image from "next/image";
 import Link from "next/link";
 import { BasicButton, Loading } from "@/components/layouts";
+import { Quest, Monster } from "@/types";
 
 interface QuestDetailProps {
   questId: number;
   quest: Quest | undefined;
   monster: Monster | undefined;
-}
-
-interface Quest {
-  id: number;
-  title: string;
-  monster_id: number;
-}
-
-interface Monster {
-  id: number;
-  name: string;
-  bestiary_monster_image_url: string;
 }
 
 const QuestDetailContainer = styled.div`
@@ -78,7 +67,11 @@ const QuestDetail: React.FC<QuestDetailProps> = ({ quest, monster }) => {
         width={250}
         height={250}
         className="border-4 border-gray-300 rounded-lg"
-        style={{ margin: '0 auto', borderRadius: '8px', border: '4px solid #ccc' }}
+        style={{
+          margin: "0 auto",
+          borderRadius: "8px",
+          border: "4px solid #ccc",
+        }}
       />
       <MonsterName>{monster.name} 1頭の狩猟</MonsterName>
       <ButtonContainer>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,13 @@
+export interface Quest {
+    id: number;
+    title: string;
+    monster_id: number;
+    monsterName: string;
+  }
+  
+  export interface Monster {
+    id: number;
+    name: string;
+    bestiary_monster_image_url: string;
+  }
+  


### PR DESCRIPTION
## 概要

以前までは各コンポーネントで必要な時にfetchを行っていましたが、その処理だとタイトルを押した際や初期表示にラグ他あり、ユーザービリティが悪いためクエスト一覧ページのfetch方法変更しました。

## 変更内容

- page.tsxで`quest`,`monster`を一度にfetchし、各コンポーネントへpropsを渡す形に変更
- 型定義のコンポーネントを作成

## 動作確認

その都度fetchするのではなく、初期表示時に一度に全てfetchしているのでユーザービリティが向上しています。

[![Image from Gyazo](https://i.gyazo.com/67732d2c6006c29485c133b70d1911bd.gif)](https://gyazo.com/67732d2c6006c29485c133b70d1911bd)