### PR TITLE
図鑑ページのレイアウト作成

### DIFF
--- a/src/app/(auth)/guildCards/encyclopedias/page.tsx
+++ b/src/app/(auth)/guildCards/encyclopedias/page.tsx
@@ -38,7 +38,7 @@ export default function MonsterEncyclopedia() {
                 >
                   {monster.name}
                 </Typography>
-                <div className="border-b border-gray-400 w-full mb-4" />
+                <div className="border-b border-white w-full mb-4" />
                 <CardMedia
                   component="img"
                   height="300"
@@ -54,6 +54,7 @@ export default function MonsterEncyclopedia() {
                 <Typography
                   variant="body2"
                   className="text-white text-center mb-2"
+                  fontSize={"20px"}
                 >
                   討伐数: {monster.kills}
                 </Typography>

--- a/src/app/(auth)/guildCards/encyclopedias/page.tsx
+++ b/src/app/(auth)/guildCards/encyclopedias/page.tsx
@@ -1,3 +1,67 @@
-export default function EncyclopediaPage() {
-  return <article>図鑑ページ</article>;
+import { Grid, Card, CardMedia, Typography, Box } from "@mui/material";
+
+export default function MonsterEncyclopedia() {
+  const defaultImage =
+    "/images/monsters/encyclopedias/monster_question_mark.jpg";
+  const monsters = [
+    { id: 1, name: "ドスジャグラス", kills: 0 },
+    { id: 2, name: "クルルヤック", kills: 0 },
+    { id: 3, name: "アンジャナフ", kills: 0 },
+    { id: 4, name: "リオレウス", kills: 0 },
+    { id: 5, name: "ディアブロス", kills: 0 },
+  ];
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[url('/images/layouts/basic_background.jpg')] bg-repeat bg-auto">
+      <div className="absolute top-10 left-1/2 transform -translate-x-1/2 text-white text-4xl font-bold z-10">
+        <p className="text-2xl sm:text-2xl md:text-5xl bg-black bg-opacity-50 p-4 rounded-md mt-2 sm:mb-2">
+          モンスター図鑑
+        </p>
+      </div>
+
+      <Box
+        sx={{
+          position: "relative",
+          zIndex: 1,
+          padding: "16px",
+          color: "white",
+        }}
+      >
+        <Grid container spacing={8} sx={{ marginTop: "76px" }}>
+          {monsters.map((monster) => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={monster.id}>
+              <Card className="bg-blue-900 bg-opacity-80 text-white h-full max-w-[300px] mx-auto border-4 border-gray-300 rounded-lg shadow-lg p-4">
+                <Typography
+                  variant="h6"
+                  component="div"
+                  className="text-center text-lg font-bold mb-2"
+                >
+                  {monster.name}
+                </Typography>
+                <div className="border-b border-gray-400 w-full mb-4" />
+                <CardMedia
+                  component="img"
+                  height="300"
+                  image={defaultImage}
+                  alt={monster.name}
+                  className="rounded-lg mx-auto mb-4 border-2 border-gray-300"
+                  style={{
+                    width: "100%",
+                    maxWidth: "220px",
+                    objectFit: "contain",
+                  }}
+                />
+                <Typography
+                  variant="body2"
+                  className="text-white text-center mb-2"
+                >
+                  討伐数: {monster.kills}
+                </Typography>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Box>
+    </div>
+  );
 }

--- a/src/app/(auth)/guildCards/encyclopedias/page.tsx
+++ b/src/app/(auth)/guildCards/encyclopedias/page.tsx
@@ -30,7 +30,7 @@ export default function MonsterEncyclopedia() {
         <Grid container spacing={8} sx={{ marginTop: "76px" }}>
           {monsters.map((monster) => (
             <Grid item xs={12} sm={6} md={4} lg={3} key={monster.id}>
-              <Card className="bg-blue-900 bg-opacity-80 text-white h-full max-w-[300px] mx-auto border-4 border-gray-300 rounded-lg shadow-lg p-4">
+              <Card className="bg-blue-900 bg-opacity-80 text-white h-full max-w-[300px] mx-auto border-4 border-gray-300 rounded-xl shadow-lg p-4">
                 <Typography
                   variant="h6"
                   component="div"
@@ -44,7 +44,7 @@ export default function MonsterEncyclopedia() {
                   height="300"
                   image={defaultImage}
                   alt={monster.name}
-                  className="rounded-lg mx-auto mb-4 border-2 border-gray-300"
+                  className="rounded-xl mx-auto mb-4 border-2 border-gray-300"
                   style={{
                     width: "100%",
                     maxWidth: "220px",

--- a/src/app/(auth)/profile/[uid]/page.tsx
+++ b/src/app/(auth)/profile/[uid]/page.tsx
@@ -14,7 +14,7 @@ import {
 import { SuccessMessage, ErrorMessage } from "@/components/layouts/messages";
 import { Settings } from "@/config";
 import { UserUid } from "@/hooks/userUid";
-import { Loading } from "@/components/layouts";
+import { BasicButton, Loading } from "@/components/layouts";
 import { GameContainerWrapper } from "@/features/quests";
 import styled from "@emotion/styled";
 import useFetchData from "@/lib/useFetchData";
@@ -153,7 +153,11 @@ export default function UserProfile() {
             >
               プロフィール
             </Typography>
-            <Stack spacing={2}>
+
+            {/* Stackに中央揃えのスタイルを追加 */}
+            <Stack spacing={2} alignItems="center" justifyContent="center">
+              {" "}
+              {/* 中央揃えの設定 */}
               <TextField
                 fullWidth
                 name="name"
@@ -195,14 +199,18 @@ export default function UserProfile() {
                   </MenuItem>
                 ))}
               </TextField>
-              <Button
-                variant="contained"
-                fullWidth
-                color="primary"
+              <BasicButton
+                text="保存"
                 onClick={handleSubmit}
-              >
-                保存
-              </Button>
+                sx={{
+                  padding: "8px 16px",
+                  fontSize: "18px",
+                  minWidth: "150px",
+                  maxWidth: "200px",
+                  margin: "10px auto",
+                  display: "block",
+                }}
+              />
             </Stack>
           </CardContent>
         </StyledCard>

--- a/src/app/(auth)/profile/[uid]/page.tsx
+++ b/src/app/(auth)/profile/[uid]/page.tsx
@@ -129,6 +129,12 @@ export default function UserProfile() {
         />
       )}
 
+      <div className="absolute top-10 left-1/2 transform -translate-x-1/2 text-white text-4xl font-bold z-10">
+        <p className="text-2xl sm:text-2xl md:text-5xl bg-black bg-opacity-50 p-4 rounded-md mt-2 sm:mb-2">
+          ハンター登録
+        </p>
+      </div>
+
       {showErrorMessage && (
         <ErrorMessage
           message="名前は1〜10文字以内で入力してください"

--- a/src/app/(auth)/quests/page.tsx
+++ b/src/app/(auth)/quests/page.tsx
@@ -68,6 +68,11 @@ export default function QuestPage() {
           onClose={() => setShowSuccessMessage(false)}
         />
       )}
+      <div className="absolute top-10 left-1/2 transform -translate-x-1/2 text-white text-4xl font-bold z-10">
+        <p className="text-2xl sm:text-2xl md:text-5xl bg-black bg-opacity-50 p-4 rounded-md mt-2 sm:mb-2">
+          クエスト一覧
+        </p>
+      </div>
 
       {/* レイアウト */}
       <div className="w-full max-w-6xl pt-4 px-4">


### PR DESCRIPTION
## 概要

モンスター図鑑ページのレイアウトを作成しました。

## 変更内容

- src/app/(auth)/guildCards/encyclopedias/page.tsxにレイアウトを作成しました
  - モンスター名,討伐数,図鑑画像を配置しました。
- quest,profileページにページの説明文を追加しました。
- profileページのボタンのサイズを最適化しました。

## 動作確認

[![Image from Gyazo](https://i.gyazo.com/a96dbf66e1bd427045303e9f3ad137be.jpg)](https://gyazo.com/a96dbf66e1bd427045303e9f3ad137be)