### PR TITLE
攻撃ボタンを押下した際に討伐数増加処理

### DIFF
--- a/src/app/(auth)/quests/[id]/battleStart/page.tsx
+++ b/src/app/(auth)/quests/[id]/battleStart/page.tsx
@@ -18,7 +18,6 @@ const BattleStart = () => {
   const [isTimeUp, setIsTimeUp] = useState(false);
   const [isImageLoaded, setIsImageLoaded] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const router = useRouter();
   const params = useParams();
   const questId = params.id;
@@ -52,33 +51,15 @@ const BattleStart = () => {
   };
 
   const handleAttack = async () => {
-    try {
-      if (!googleUserId) {
-        throw new Error("ユーザーIDが取得できませんでした。");
-      }
+    if (!googleUserId || !monster) return;
 
-      if (!monster) {
-        throw new Error("モンスターデータが取得できませんでした。");
-      }
+    await fetcher(
+      `${Settings.API_URL}/api/v1/guild_cards/${googleUserId}/increment_defeat_count`,
+      "POST",
+      { monster_id: monster.id }
+    );
 
-      const response = await fetcher(
-        `${Settings.API_URL}/api/v1/guild_cards/${googleUserId}/increment_defeat_count`,
-        "POST",
-        {
-          monster_id: monster.id,
-        }
-      );
-
-      if (response) {
-        router.push(`/quests/${questId}/battleEnd`);
-      } else {
-        setErrorMessage("攻撃に失敗しました。もう一度お試しください。");
-      }
-    } catch (error) {
-      setErrorMessage(
-        error instanceof Error ? error.message : "エラーが発生しました"
-      );
-    }
+    router.push(`/quests/${questId}/battleEnd`);
   };
 
   if (!monster) {
@@ -112,9 +93,7 @@ const BattleStart = () => {
             {!isStarted ? (
               <BasicButton
                 text="戦闘開始"
-                onClick={() => {
-                  setIsStarted(true);
-                }}
+                onClick={() => setIsStarted(true)}
                 style={{
                   fontSize: "34px",
                   padding: "16px 42px",
@@ -126,22 +105,15 @@ const BattleStart = () => {
                 {formatTime(countdown)}
               </Typography>
             ) : (
-              <>
-                {errorMessage && (
-                  <Typography variant="body1" color="error">
-                    {errorMessage}
-                  </Typography>
-                )}
-                <SecondaryButton
-                  text="攻撃する"
-                  onClick={handleAttack}
-                  style={{
-                    fontSize: "34px",
-                    padding: "16px 42px",
-                    marginTop: "400px",
-                  }}
-                />
-              </>
+              <SecondaryButton
+                text="攻撃する"
+                onClick={handleAttack}
+                style={{
+                  fontSize: "34px",
+                  padding: "16px 42px",
+                  marginTop: "400px",
+                }}
+              />
             )}
           </div>
         </>

--- a/src/contexts/auth/index.tsx
+++ b/src/contexts/auth/index.tsx
@@ -4,19 +4,7 @@ import React, { createContext, useContext, useEffect, useState, ReactNode, useCa
 import { useRouter, usePathname } from "next/navigation";
 import { jwtDecode } from "jwt-decode";
 import { Settings } from "@/config";
-
-interface AuthContextType {
-  token: string | null;
-  googleUserId: string | null;
-  currentUser: any;
-  setToken: (token: string) => void;
-  logout: () => void;
-}
-
-interface JwtPayload {
-  google_user_id: string;
-  exp: number;
-}
+import { AuthContextType, JwtPayload } from "@/types"
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 

--- a/src/lib/fetcher/index.tsx
+++ b/src/lib/fetcher/index.tsx
@@ -1,6 +1,6 @@
 const fetcher = async (
   url: string,
-  method: "GET" | "PATCH" = "GET",
+  method: "GET" | "PATCH" | "POST" = "GET",
   data?: any
 ): Promise<any> => {
   const token = localStorage.getItem("authToken");
@@ -17,7 +17,8 @@ const fetcher = async (
     },
   };
 
-  if (method === "PATCH" && data) {
+  // PATCHまたはPOSTの場合に、リクエストボディを設定
+  if ((method === "PATCH" || method === "POST") && data) {
     options.body = JSON.stringify(data);
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,3 +22,16 @@ export interface GuildCard {
   defeat_count: number;
   monster: Monster;
 }
+
+export interface AuthContextType {
+  token: string | null;
+  googleUserId: string | null;
+  currentUser: any;
+  setToken: (token: string) => void;
+  logout: () => void;
+}
+
+export interface JwtPayload {
+  google_user_id: string;
+  exp: number;
+}


### PR DESCRIPTION
## 概要

戦闘開始ページにて攻撃ボタンを押した際にユーザーごとのモンスター討伐数を+1にするための処理を行いました。

## 変更内容

- `攻撃する`ボタンを押した際に(api/v1/guild_cards/${googleUserId}/increment_defeat_count)にPOSTの処理
- `src/lib/fetcher/index.tsx`にてPOSTの処理の追加
- `src/contexts/auth/index.tsx`の型定義を`src/types/index.ts`へ移動し、一括管理

## 動作確認

- [x] 攻撃するボタンを押した際に討伐数が+1されている

[![Image from Gyazo](https://i.gyazo.com/c5c333af7855707f0549f457dc81520b.gif)](https://gyazo.com/c5c333af7855707f0549f457dc81520b)

## 補足

今後の動作確認のため5分の設定を3秒に変更しました。