### PR TITLE
userAvatarのfetch処理

### DIFF
--- a/src/components/layouts/userAvatar/index.tsx
+++ b/src/components/layouts/userAvatar/index.tsx
@@ -1,26 +1,55 @@
-import { FC } from "react";
+"use client";
+
+import { FC, useEffect, useState } from "react";
 import Image from "next/image";
+import { useAuth } from "@/contexts/auth";
+import { Settings } from "@/config";
+import useFetchData from "@/lib/useFetchData";
+import { UserData } from "@/types";
 
 const UserAvatar: FC = () => {
-  const imageUrl = "/images/userAvatars/female.jpg";
-  const hunterRank = 20;
+  const { googleUserId } = useAuth();
+  const [hunterRank, setHunterRank] = useState<number | null>(null);
+  const [gender, setGender] = useState<string | null>(null);
+
+  const userData = useFetchData<UserData>(
+    googleUserId ? `${Settings.API_URL}/api/v1/users/${googleUserId}` : ""
+  );
+
+  useEffect(() => {
+    console.log("取得したGoogle User ID:", googleUserId);
+    console.log("取得したユーザーデータ:", userData);
+
+    if (userData) {
+      setHunterRank(userData.hunterRank);
+      console.log("設定されたハンターランク:", userData.hunterRank);
+      setGender(userData.gender);
+      console.log("設定された性別:", userData.gender);
+    }
+  }, [userData, googleUserId]);
+
+  const imageUrl = gender ? `/images/userAvatars/${gender}.jpg` : "";
 
   return (
     <div className="fixed bottom-20 left-4 flex flex-col items-center z-50">
-      {/* アバターの背景円 */}
+      {/* アバター */}
       <div className="relative w-24 h-24 bg-[#1E3A8A] rounded-full flex items-center justify-center shadow-md">
-        <Image
-          src={imageUrl}
-          alt="User Avatar"
-          className="rounded-full"
-          width={90}
-          height={90}
-        />
+        {imageUrl && (
+          <Image
+            src={imageUrl}
+            alt="User Avatar"
+            className="rounded-full"
+            width={90}
+            height={90}
+          />
+        )}
       </div>
-      {/* ハンターランク表示 */}
-      <div className="absolute bottom-[-8px] right-[-8px] bg-white text-blue-600 rounded-full w-8 h-8 flex items-center justify-center text-sm font-bold shadow-md">
-        {hunterRank}
-      </div>
+      {/* ハンターランク*/}
+      {hunterRank !== null && (
+        <div className="absolute bottom-[-8px] right-[-8px] bg-white text-[#1E3A8A] rounded-full w-12 h-8 flex items-center justify-center text-sm font-bold shadow-md">
+          HR: {hunterRank}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/layouts/userAvatar/index.tsx
+++ b/src/components/layouts/userAvatar/index.tsx
@@ -30,6 +30,10 @@ const UserAvatar: FC = () => {
 
   const imageUrl = gender ? `/images/userAvatars/${gender}.jpg` : "";
 
+  if (!googleUserId) {
+    return null;
+  }
+
   return (
     <div className="fixed bottom-20 left-4 flex flex-col items-center z-50">
       {/* アバター */}
@@ -44,7 +48,7 @@ const UserAvatar: FC = () => {
           />
         )}
       </div>
-      {/* ハンターランク*/}
+      {/* ハンターランク */}
       {hunterRank !== null && (
         <div className="absolute bottom-[-8px] right-[-8px] bg-white text-[#1E3A8A] rounded-full w-12 h-8 flex items-center justify-center text-sm font-bold shadow-md">
           HR: {hunterRank}

--- a/src/lib/fetcher/index.tsx
+++ b/src/lib/fetcher/index.tsx
@@ -17,7 +17,6 @@ const fetcher = async (
     },
   };
 
-  // PATCHまたはPOSTの場合に、リクエストボディを設定
   if ((method === "PATCH" || method === "POST") && data) {
     options.body = JSON.stringify(data);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,7 @@ export interface Monster {
 export interface UserData {
   name: string;
   gender: string;
+  hunterRank: number;
 }
 
 export interface GuildCard {


### PR DESCRIPTION
## 概要

userAvatarコンポーネントを動的に表示し、ユーザーごとの性別、HRに合わせた表示を行いました。

## 変更内容

- uidを取得しuserDataを取得
- ユーザーごとの性別、HRをそれぞれGET処理
- ログインしているかいないかでの表示のon/off
- `hunterRank`の型定義の追加

## 動作確認

- [x] ユーザーの性別ごとのアバターが表示されていること
- [x] ユーザーのHRごとにHRが表示されていること

[![Image from Gyazo](https://i.gyazo.com/1e3133375aa47226573bd973e0a37516.jpg)](https://gyazo.com/1e3133375aa47226573bd973e0a37516)