### PR TITLE
hunterRankのPATCH処理

### DIFF
--- a/src/app/(auth)/quests/[id]/battleStart/page.tsx
+++ b/src/app/(auth)/quests/[id]/battleStart/page.tsx
@@ -66,6 +66,11 @@ const BattleStart = () => {
       { monster_id: monster.id }
     );
 
+    await fetcher(
+      `${Settings.API_URL}/api/v1/users/${googleUserId}/increment_hunter_rank`,
+      "PATCH"
+    );
+
     router.push(`/quests/${questId}/battleEnd`);
   };
 


### PR DESCRIPTION
## 概要

ユーザーが5分間の掃除終了後`攻撃する`ボタンを押下すると`hunterRank`が+1上昇するfetch処理を行いました。

## 変更内容

- `api/v1/users/${googleUserId}/increment_hunter_rank`のエンドポイントから`hunterRank`をPATCHの処理

## 動作確認

- [x] 攻撃するボタンを押下すると`hunterRank`が+1されていること

[![Image from Gyazo](https://i.gyazo.com/31d4e036f6fd7ef7f5e390a2a525cd62.gif)](https://gyazo.com/31d4e036f6fd7ef7f5e390a2a525cd62)