### PR TITLE
ボタン押下時にレコード作成、討伐時刻保存の処理追加

### DIFF
--- a/src/app/(auth)/quests/[id]/battleStart/page.tsx
+++ b/src/app/(auth)/quests/[id]/battleStart/page.tsx
@@ -57,8 +57,19 @@ const BattleStart = () => {
     setIsLoading(false);
   };
 
+  const handleStartBattle = async () => {
+    if (!googleUserId || !questId) return;
+
+    await fetcher(
+      `${Settings.API_URL}/api/v1/user_quests`,
+      "POST",
+      { quest_id: questId }
+    );
+    setIsStarted(true);
+  };
+
   const handleAttack = async () => {
-    if (!googleUserId || !monster) return;
+    if (!googleUserId || !monster || !questId) return;
 
     await fetcher(
       `${Settings.API_URL}/api/v1/guild_cards/${googleUserId}/increment_defeat_count`,
@@ -68,6 +79,11 @@ const BattleStart = () => {
 
     await fetcher(
       `${Settings.API_URL}/api/v1/users/${googleUserId}/increment_hunter_rank`,
+      "PATCH"
+    );
+
+    await fetcher(
+      `${Settings.API_URL}/api/v1/user_quests/${questId}/complete`,
       "PATCH"
     );
 
@@ -105,7 +121,7 @@ const BattleStart = () => {
             {!isStarted ? (
               <BasicButton
                 text="戦闘開始"
-                onClick={() => setIsStarted(true)}
+                onClick={handleStartBattle}
                 style={{
                   fontSize: "34px",
                   padding: "16px 42px",


### PR DESCRIPTION
## 概要

ボタンを押下した際にレコードが作成される処理、討伐時刻が保存される処理をバックエンドへリクエストする処理を追加しました。

## 変更内容

- 戦闘開始ボタンを押下
  - POST: `/api/v1/user_quests`のエンドポイントからレコード作成
- 攻撃するボタン押下
  - PTACT: `/api/v1/user_quests/[id]/complete`のエンドポイントから討伐時刻を追加

## 動作確認

- [x] それぞれのボタンが押下された際に、`POST`,`PATCH`の処理がそれぞれ行われている

[![Image from Gyazo](https://i.gyazo.com/135c979d904465030667f7a5e63384d0.png)](https://gyazo.com/135c979d904465030667f7a5e63384d0)