### PR TITLE
ログインしているか否かで下部ナビゲーションの切り出し追加

### DIFF
--- a/src/components/layouts/bottomNavigation/index.tsx
+++ b/src/components/layouts/bottomNavigation/index.tsx
@@ -39,6 +39,10 @@ export default function SimpleBottomNavigation() {
     }
   };
 
+  if (!googleUserId) {
+    return null;
+  }
+
   return (
     <div>
       <Box


### PR DESCRIPTION
## 概要

ログインしていない場合に下部ナビゲーションを非表示にする処理を追加しました。

## 変更内容

- localstrageに保存されているtokenから`googleUserId`が検出されなければ非表示

## 動作確認

- [x] ログインしていない場合(localstrageにtokenがない場合)下部ナビゲーションが非表示になっていること
- [x] ログインしている場合(localstrageにtokenがある場合)下部ナビゲーションが表示されていること

| 未ログイン時 | ログイン時 |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/4759692f7d0cefb6ba2ea061f2d4663d.jpg)](https://gyazo.com/4759692f7d0cefb6ba2ea061f2d4663d) | [![Image from Gyazo](https://i.gyazo.com/a8b11968d56e3c63fb238f20ab7a1d0c.jpg)](https://gyazo.com/a8b11968d56e3c63fb238f20ab7a1d0c) |