### PR TITLE
encyclopediasページの画面下部にpaddingを追加

### DIFF
--- a/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
@@ -58,6 +58,7 @@ export default function MonsterEncyclopedia() {
           zIndex: 1,
           padding: "16px",
           color: "white",
+          paddingBottom: "80px",
         }}
       >
         <Grid container spacing={8} sx={{ marginTop: "76px" }}>


### PR DESCRIPTION
## 概要

図鑑ページの画面下部のレイアウトを修正しました。

## 変更内容

- paddingBottom追加

## 動作確認

- [x] 下部ナビゲーションバーに隠れていた部分が表示されている

| 変更前 | 変更後 |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/3518718397659e3050a9e46f609147cf.jpg)](https://gyazo.com/3518718397659e3050a9e46f609147cf) | [![Image from Gyazo](https://i.gyazo.com/5edc18e3585f65329d68b9eff4738e0b.jpg)](https://gyazo.com/5edc18e3585f65329d68b9eff4738e0b) |