### PR TITLE
活動履歴、掃除箇所グラフ化の実装のためのセットアップ

### DIFF
--- a/src/app/(auth)/guildCards/cleanAreaGraph/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/cleanAreaGraph/[uid]/page.tsx
@@ -1,0 +1,7 @@
+export default function CleanAreaGraph() {
+  return (
+    <div>
+      <div>掃除箇所グラフページ</div>
+    </div>
+  );
+}

--- a/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
@@ -1,0 +1,7 @@
+export default function DailyHuntLog() {
+  return (
+    <div>
+      <div>デイリー討伐記録ページ</div>
+    </div>
+  );
+}

--- a/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
@@ -45,7 +45,7 @@ export default function MonsterEncyclopedia() {
   if (!monstersData) return <Loading />;
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[url('/images/layouts/basic_background.jpg')] bg-auto bg-repeat">
+    <div className="relative min-h-screen overflow-hidden bg-auto bg-repeat">
       <div className="absolute left-1/2 top-10 z-10 -translate-x-1/2 text-4xl font-bold text-white">
         <p
           className="mt-2 min-w-[300px] rounded-md bg-black/50 p-4 text-center text-2xl sm:mb-2 sm:text-2xl md:text-5xl"

--- a/src/app/(auth)/guildCards/layout.tsx
+++ b/src/app/(auth)/guildCards/layout.tsx
@@ -1,0 +1,12 @@
+// import { GuildCardsTab } from '@/components/layouts';
+import { GuildCardsLayoutProps } from '@/types';
+
+export default function GeneralLayout({ children }: GuildCardsLayoutProps) {
+  return (
+    <div>
+      {/* 本番環境に影響を及ばさないように活動履歴、掃除場所の実装が出来次第、表示 */}
+      {/* <GuildCardsTab /> */}
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,17 @@
+import { AuthLayoutProps } from '@/types';
+import Image from 'next/image';
+
+export default function GeneralLayout({ children }: AuthLayoutProps) {
+  return (
+    <div className="relative">
+      <Image
+        src="/images/layouts/basic_background.jpg"
+        alt="Basic Background Image"
+        fill
+        style={{ objectFit: 'cover' }}
+        className="z-0"
+      />
+      <main className="relative z-10">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,5 +1,5 @@
-import { AuthLayoutProps } from '@/types';
 import Image from 'next/image';
+import { AuthLayoutProps } from '@/types';
 
 export default function GeneralLayout({ children }: AuthLayoutProps) {
   return (

--- a/src/app/(general)/layout.tsx
+++ b/src/app/(general)/layout.tsx
@@ -1,9 +1,5 @@
-import { ReactNode } from 'react';
 import { Headers, Footers } from '@/components/layouts';
-
-interface GeneralLayoutProps {
-  children: ReactNode;
-}
+import { GeneralLayoutProps } from '@/types';
 
 export default function GeneralLayout({ children }: GeneralLayoutProps) {
   return (

--- a/src/components/layouts/guildCardsTab/index.tsx
+++ b/src/components/layouts/guildCardsTab/index.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useAuth } from '@/contexts/auth';
+
+const CustomTabs: React.FC = () => {
+  const [selectedTab, setSelectedTab] = useState(0);
+  const router = useRouter();
+  const { googleUserId } = useAuth();
+
+  const tabPaths = googleUserId
+    ? [
+        `/guildCards/encyclopedias/${googleUserId}`,
+        `/guildCards/dailyHuntLog/${googleUserId}`,
+        `/guildCards/cleanAreaGraph/${googleUserId}`,
+      ]
+    : [];
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setSelectedTab(newValue);
+    if (googleUserId) {
+      router.push(tabPaths[newValue]);
+    }
+  };
+
+  if (!googleUserId) {
+    return null;
+  }
+
+  return (
+    <div>
+      <Box
+        sx={{
+          borderBottom: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <Tabs
+          value={selectedTab}
+          onChange={handleTabChange}
+          aria-label="navigation tabs"
+          variant="fullWidth"
+          className="rounded-md bg-white shadow-md"
+        >
+          <Tab label="図鑑" className="font-medium text-gray-800" />
+          <Tab label="活動履歴" className="font-medium text-gray-800" />
+          <Tab label="掃除場所" className="font-medium text-gray-800" />
+        </Tabs>
+      </Box>
+    </div>
+  );
+};
+
+export default CustomTabs;

--- a/src/components/layouts/index.js
+++ b/src/components/layouts/index.js
@@ -2,6 +2,7 @@ import BasicButton from './basicButton';
 import BlackButton from './blackButton';
 import BottomNavigation from './bottomNavigation';
 import Footers from './footers';
+import GuildCardsTab from './guildCardsTab';
 import Headers from './headers';
 import Loading from './loading';
 import SecondaryButton from './secondaryButton';
@@ -16,4 +17,5 @@ export {
   SecondaryButton,
   BlackButton,
   UserAvatar,
+  GuildCardsTab,
 };

--- a/src/features/quests/gameContainerWrapper/index.tsx
+++ b/src/features/quests/gameContainerWrapper/index.tsx
@@ -7,7 +7,6 @@ export const GameContainerWrapper: React.FC<{ children: React.ReactNode }> = ({
 };
 
 const GameContainer = styled.div`
-  background-image: url('/images/layouts/basic_background.jpg');
   background-repeat: repeat;
   background-size: auto;
   min-height: 100vh;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,4 +76,7 @@ export interface AuthLayoutProps {
   children: ReactNode;
 }
 
+export interface GuildCardsLayoutProps {
+  children: ReactNode;
+}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 export interface Quest {
   id: number;
   title: string;
@@ -65,3 +67,13 @@ export interface MobileDialogProps {
   quest: Quest | undefined;
   monster: Monster | undefined;
 }
+
+export interface GeneralLayoutProps {
+  children: ReactNode;
+}
+
+export interface AuthLayoutProps {
+  children: ReactNode;
+}
+
+


### PR DESCRIPTION
## 概要

活動履歴、掃除箇所グラフ化の実装のためにディレクトリ及びタブバーコンポーネントの作成。

## 変更内容

- `src/app/(auth)/layout.tsx`を作成し、`(auth)`配下のページに背景画像を配置
- `guildCards`の配下に`dailyHuntLog`,`cleanAreaGraph`を配置し、ページを作成
- `guildCard`配下でタブバーが使えるように`src/components/layouts/guildCardsTab/index.tsx`を作成
  - それぞれのページへ`googleId(uid)`を元に個別の画面遷移になるよう作成
  - `src/app/(auth)/guildCards/layout.tsx`でタブバーをimport

## 動作確認

⚠️コメントアウトをはずした状態での動作確認となっています。

- [x] タブを押下した際にそれぞれのページへ遷移すること

[![Image from Gyazo](https://i.gyazo.com/ed5a0c6ae8e0fe3c8c8488ac1dc053c7.gif)](https://gyazo.com/ed5a0c6ae8e0fe3c8c8488ac1dc053c7)

## 連絡事項

今回タブバーを実装しましたが、現状`dailyHuntLog`,`cleanAreaGraph`のページの実装がされていませんの`layout.tsx`ではコメントアウトとなっています。実装が終わり次第コメントアウトを外す予定です。