### PR TITLE
活動履歴ページのレイアウト作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^6.0.1",
     "@mui/material": "^6.0.0-rc.0",
+    "date-fns": "^4.1.0",
     "jwt-decode": "^4.0.0",
     "next": "14.2.7",
     "react": "^18",

--- a/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
@@ -1,7 +1,153 @@
+'use client';
+
+import styled from '@emotion/styled';
+import { Typography, Card, CardContent } from '@mui/material';
+import {
+  eachDayOfInterval,
+  format,
+  parseISO,
+  addMonths,
+  subMonths,
+  startOfMonth,
+  endOfMonth,
+  getDay,
+} from 'date-fns';
+import Image from 'next/image';
+import { useState, useEffect } from 'react';
+import { BasicButton } from '@/components/layouts';
+
+const mockData = [
+  { defeated_at: '2024-10-01T12:34:56Z' },
+  { defeated_at: '2024-10-02T08:23:12Z' },
+  { defeated_at: '2024-10-04T17:11:22Z' },
+  { defeated_at: '2024-10-07T15:45:32Z' },
+];
+
+interface ActivityRecord {
+  date: string;
+  defeated: boolean;
+}
+
+const StyledCard = styled(Card)`
+  background-color: rgba(30, 58, 138, 0.8);
+  border: 3px solid #c0c0c0;
+  border-radius: 15px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
+  color: white;
+  padding: 16px;
+  margin-top: 24px;
+`;
+
 export default function DailyHuntLog() {
+  const [currentMonth, setCurrentMonth] = useState(new Date());
+  const [activityLog, setActivityLog] = useState<ActivityRecord[]>([]);
+
+  useEffect(() => {
+    const start = startOfMonth(currentMonth);
+    const end = endOfMonth(currentMonth);
+    const monthDays = eachDayOfInterval({ start, end });
+
+    const firstDayOfWeek = getDay(start);
+
+    const emptyDays = Array(firstDayOfWeek).fill(null);
+
+    const logData = monthDays.map((date) => {
+      const dateString = format(date, 'yyyy-MM-dd');
+      const defeated = mockData.some((record) =>
+        record.defeated_at.startsWith(dateString),
+      );
+      return { date: dateString, defeated };
+    });
+
+    setActivityLog([...emptyDays, ...logData]);
+  }, [currentMonth]);
+
+  const goToNextMonth = () => {
+    setCurrentMonth(addMonths(currentMonth, 1));
+  };
+
+  const goToPreviousMonth = () => {
+    setCurrentMonth(subMonths(currentMonth, 1));
+  };
+
+  const daysOfWeek = ['日', '月', '火', '水', '木', '金', '土'];
+
   return (
-    <div>
-      <div>デイリー討伐記録ページ</div>
+    <div className="flex min-h-screen flex-col items-center justify-center p-4">
+      <div className="absolute left-1/2 top-16 z-10 mt-2 -translate-x-1/2 text-4xl font-bold text-white">
+        <p
+          className="mt-2 min-w-[300px] rounded-md bg-black/50 p-4 text-center text-2xl sm:mb-2 sm:text-2xl md:text-5xl"
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          日別の活動履歴
+        </p>
+      </div>
+      <StyledCard>
+        <CardContent>
+          <Typography
+            variant="h5"
+            align="center"
+            gutterBottom
+            sx={{
+              fontWeight: 'bold',
+              marginBottom: '16px',
+              borderBottom: '2px solid #ccc',
+              paddingBottom: '8px',
+            }}
+          >
+            {format(currentMonth, 'yyyy年M月の活動履歴')}
+          </Typography>
+          <div className="grid grid-cols-7 gap-2">
+            {daysOfWeek.map((day, index) => (
+              <div key={index} className="text-center font-bold text-white">
+                {day}
+              </div>
+            ))}
+            {activityLog.map((record, index) => (
+              <div
+                key={index}
+                className="flex size-10 items-center justify-center rounded-md"
+                style={{
+                  backgroundColor:
+                    record && record.defeated ? '#1E3A8A' : '#f0f0f0',
+                  color: record && record.defeated ? 'white' : 'black',
+                  border: '2px solid #ccc',
+                }}
+              >
+                {record ? (
+                  record.defeated ? (
+                    <Image
+                      src="/images/favicon/favicon.png"
+                      alt="Activity Stamp"
+                      width={24}
+                      height={24}
+                    />
+                  ) : (
+                    <span className="text-sm">
+                      {format(parseISO(record.date), 'd')}
+                    </span>
+                  )
+                ) : (
+                  <span></span>
+                )}
+              </div>
+            ))}
+          </div>
+          <div className="mt-6 flex flex-nowrap justify-between space-x-4">
+            <BasicButton
+              text="◀️前の月"
+              onClick={goToPreviousMonth}
+              style={{ padding: '6px 12px', fontSize: '14px' }}
+            />
+
+            <BasicButton
+              text="次の月▶️"
+              onClick={goToNextMonth}
+              style={{ padding: '6px 12px', fontSize: '14px' }}
+            />
+          </div>
+        </CardContent>
+      </StyledCard>
     </div>
   );
 }

--- a/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
@@ -79,7 +79,7 @@ export default function DailyHuntLog() {
           className="mt-2 min-w-[300px] rounded-md bg-black/50 p-4 text-center text-2xl sm:mb-2 sm:text-2xl md:text-5xl"
           style={{ whiteSpace: 'nowrap' }}
         >
-          日別の活動履歴
+          月別の活動履歴
         </p>
       </div>
       <StyledCard>

--- a/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
@@ -46,7 +46,7 @@ export default function MonsterEncyclopedia() {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-auto bg-repeat">
-      <div className="absolute left-1/2 top-10 z-10 -translate-x-1/2 text-4xl font-bold text-white">
+      <div className="absolute left-1/2 top-6 z-10 -translate-x-1/2 text-4xl font-bold text-white">
         <p
           className="mt-2 min-w-[300px] rounded-md bg-black/50 p-4 text-center text-2xl sm:mb-2 sm:text-2xl md:text-5xl"
           style={{ whiteSpace: 'nowrap' }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,6 +1099,11 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"


### PR DESCRIPTION
## 概要

ユーザーの活動履歴を可視化するための`dailyHuntLog`ページのレイアウトを作成しました。

## 変更内容

- `src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx`にレイアウト作成
- 日付操作を行うために[date-fns](https://classic.yarnpkg.com/en/package/date-fns)のパッケージをインストール
- `src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx`にてページタイトルの高さを調整

## 動作確認

- [x] 活動履歴がある日にはスタンプが押下されていること
- [x] 月別の活動履歴を閲覧できること
- [x] PC,スマホなどのレスポンシブデザインになっていること

| PC | スマホ |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/8b4a9896254bd1ba0a2b8938e7ac085a.jpg)](https://gyazo.com/8b4a9896254bd1ba0a2b8938e7ac085a) |  [![Image from Gyazo](https://i.gyazo.com/b3c8c7179ec1e3e63732f6e9c2e8a910.gif)](https://gyazo.com/b3c8c7179ec1e3e63732f6e9c2e8a910) |