### PR TITLE
sleep処理の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ $ yarn format
 - [Pretteir](https://prettier.io/docs/en/install.html)
 - [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier)
 - [date-fns](https://date-fns.org/)
+- [NoSleep.js](https://github.com/richtr/NoSleep.js)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "date-fns": "^4.1.0",
     "jwt-decode": "^4.0.0",
     "next": "14.2.7",
+    "nosleep.js": "^0.12.0",
     "react": "^18",
     "react-dom": "^18",
     "swr": "^2.2.5"

--- a/src/app/(auth)/quests/[id]/battleStart/page.tsx
+++ b/src/app/(auth)/quests/[id]/battleStart/page.tsx
@@ -3,6 +3,7 @@
 import { Typography } from '@mui/material';
 import Image from 'next/image';
 import { useParams, useRouter } from 'next/navigation';
+import NoSleep from 'nosleep.js';
 import { useState, useEffect, useRef } from 'react';
 import { BasicButton, SecondaryButton, Loading } from '@/components/layouts';
 import { Settings } from '@/config';
@@ -10,7 +11,6 @@ import { useAuth } from '@/contexts/auth';
 import fetcher from '@/lib/fetcher';
 import useFetchData from '@/lib/useFetchData';
 import { Monster } from '@/types';
-import NoSleep from 'nosleep.js';
 
 const BattleStart = () => {
   const { googleUserId } = useAuth();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2439,6 +2439,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+nosleep.js@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/nosleep.js/-/nosleep.js-0.12.0.tgz#a01fddab2c13af357d673928b1f40a9013a4dc08"
+  integrity sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==
+
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"


### PR DESCRIPTION
## 概要

現状、モバイル版だと戦闘開始ボタンを押下後しばらく操作がないとスリープ状態になっていた部分を改善しました。

## 変更内容

- [nosleep.js](https://github.com/richtr/NoSleep.js)ライブラリのインストール
- 不要になった`Wake Lock API `の処理を削除
- nosleep.jsライブラリを使用してsleep防止実装

## 動作確認

- console上に`NoSleep.js enabled`と表示されていること
下記のようなconsoleを仕掛けました。
```
const handleStartBattle = async () => {

~~~~~~~~~~~~~~

  // 戦闘開始時に NoSleep.js を有効化
  noSleepRef.current?.enable();
  console.log('NoSleep.js enabled');  // ここでログを出力

  setIsStarted(true);
};
```
[![Image from Gyazo](https://i.gyazo.com/c13dba7db47865b0c114279f001eb792.jpg)](https://gyazo.com/c13dba7db47865b0c114279f001eb792)

## 連絡事項

consoleでの確認はできましたが、実際のモバイル版だと機能しているかの確認が困難なためマージ後に確認し、できてイナケラば再度修正します。