### PR TITLE
defeated_atをAPIから取得

### DIFF
--- a/src/app/(auth)/guildCards/layout.tsx
+++ b/src/app/(auth)/guildCards/layout.tsx
@@ -1,11 +1,10 @@
-// import { GuildCardsTab } from '@/components/layouts';
+import { GuildCardsTab } from '@/components/layouts';
 import { GuildCardsLayoutProps } from '@/types';
 
 export default function GeneralLayout({ children }: GuildCardsLayoutProps) {
   return (
     <div>
-      {/* 本番環境に影響を及ばさないように活動履歴、掃除場所の実装が出来次第、表示 */}
-      {/* <GuildCardsTab /> */}
+      <GuildCardsTab />
       <main>{children}</main>
     </div>
   );

--- a/src/components/layouts/bottomNavigation/index.tsx
+++ b/src/components/layouts/bottomNavigation/index.tsx
@@ -63,7 +63,7 @@ export default function SimpleBottomNavigation() {
         >
           <BottomNavigationAction label="ホーム" icon={<HomeIcon />} />
           <BottomNavigationAction label="クエスト" icon={<AssignmentIcon />} />
-          <BottomNavigationAction label="図鑑" icon={<BookIcon />} />
+          <BottomNavigationAction label="ギルドカード" icon={<BookIcon />} />
           <BottomNavigationAction label="ユーザー" icon={<PersonIcon />} />
         </BottomNavigation>
       </Box>

--- a/src/components/layouts/guildCardsTab/index.tsx
+++ b/src/components/layouts/guildCardsTab/index.tsx
@@ -48,7 +48,8 @@ const CustomTabs: React.FC = () => {
         >
           <Tab label="図鑑" className="font-medium text-gray-800" />
           <Tab label="活動履歴" className="font-medium text-gray-800" />
-          <Tab label="掃除場所" className="font-medium text-gray-800" />
+          {/* ページ出来上がり次第表示 */}
+          {/* <Tab label="掃除場所" className="font-medium text-gray-800" /> */}
         </Tabs>
       </Box>
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,3 +79,12 @@ export interface AuthLayoutProps {
 export interface GuildCardsLayoutProps {
   children: ReactNode;
 }
+
+export interface DefeatedRecordsData {
+  defeated_at: string[];
+}
+
+export interface ActivityRecord {
+  date: string;
+  defeated: boolean;
+}


### PR DESCRIPTION
## 概要

`defeated_at`をAPIから取得しユーザーごとの活動記録を動的に表示しました。

## 変更内容

- `/api/v1/user_quests/defeated_records/${googleUserId}`このエンドポイントから取得
- fetchされるまで`<Loading />`コンポーネント表示
- layout.tsxにて`<GuildCardsTab/ >`コンポーネントの有効化

## 動作確認

- [x] バックから取得した値が正しく画面に表示されているか

| defeated_atの値 | 画面の表示 |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/8e7fa059e84b703904674775ec516e2b.png)](https://gyazo.com/8e7fa059e84b703904674775ec516e2b) | [![Image from Gyazo](https://i.gyazo.com/4b8ee925b2bb5c00d08df95d608f3deb.jpg)](https://gyazo.com/4b8ee925b2bb5c00d08df95d608f3deb) |

## 連絡事項

掃除箇所のグラフ化するページを実装する際に`src/components/layouts/guildCardsTab/index.tsx`のコメントアウトを解除して、タブバーの追加を行います。