### PR TITLE
apiからdefeat_atの値を取得してグラフを動的に表示

### DIFF
--- a/src/components/layouts/guildCardsTab/index.tsx
+++ b/src/components/layouts/guildCardsTab/index.tsx
@@ -48,8 +48,7 @@ const CustomTabs: React.FC = () => {
         >
           <Tab label="図鑑" className="font-medium text-gray-800" />
           <Tab label="活動履歴" className="font-medium text-gray-800" />
-          {/* ページ出来上がり次第表示 */}
-          {/* <Tab label="掃除場所" className="font-medium text-gray-800" /> */}
+          <Tab label="掃除場所" className="font-medium text-gray-800" />
         </Tabs>
       </Box>
     </div>


### PR DESCRIPTION
## 概要

各ユーザーの掃除場所ごとの回数を可視化するために、ダミーデータの`defeat_cout`をapiから取得し、動的に表示するようにしました。

## 変更内容

- `/api/v1/guild_cards/defeated_records/${googleUserId}`このエンドポイントから`defeat_cout`を取得
- cleanAreaGraphページの実装が完了したので、`<GuildCardsTab />`コンポーネントを有効化

## 動作確認

- [x] cleanAreaGraphページにアクセスした際にapiから取得した`defeat_count`とグラフの値が一致していること

| apiのdefeat_count | グラフの表示 |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/e7f4ca52a6560c3ae52f28c978bec04e.png)](https://gyazo.com/e7f4ca52a6560c3ae52f28c978bec04e) | [![Image from Gyazo](https://i.gyazo.com/9319d10ddd9058c4f049e7de7c33ba12.jpg)](https://gyazo.com/9319d10ddd9058c4f049e7de7c33ba12) |