### PR TITLE
(common)ディレクトリ配下の各ページ作成

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import { AuthLayoutProps } from '@/types';
 
-export default function GeneralLayout({ children }: AuthLayoutProps) {
+export default function AuthLayout({ children }: AuthLayoutProps) {
   return (
     <div className="relative">
       <Image

--- a/src/app/(common)/contact/page.tsx
+++ b/src/app/(common)/contact/page.tsx
@@ -1,0 +1,3 @@
+export default function Contact() {
+  return <div>お問い合わせ</div>;
+}

--- a/src/app/(common)/contact/page.tsx
+++ b/src/app/(common)/contact/page.tsx
@@ -1,3 +1,15 @@
 export default function Contact() {
-  return <div>お問い合わせ</div>;
+  return (
+    <div>
+      {' '}
+      <div className="absolute left-1/2 top-4 z-10 mt-2 -translate-x-1/2 text-4xl font-bold text-white">
+        <p
+          className="mt-2 min-w-[300px] rounded-md bg-black/50 p-4 text-center text-2xl sm:mb-2 sm:text-2xl md:text-5xl"
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          お問い合わせ
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/src/app/(common)/layout.tsx
+++ b/src/app/(common)/layout.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image';
+import { Footers, Headers } from '@/components/layouts';
+import { CommonLayoutProps } from '@/types';
+
+export default function CommonLayout({ children }: CommonLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Headers />
+      <main className="relative z-10">{children}</main>
+
+      <div className="relative grow">
+        <div className="relative h-[calc(100vh-150px)] w-full">
+          <Image
+            src="/images/layouts/basic_background.jpg"
+            alt="Basic Background Image"
+            fill
+            style={{ objectFit: 'cover' }}
+            className="absolute left-0 top-0 -z-10 size-full"
+          />
+        </div>
+      </div>
+      <Footers />
+    </div>
+  );
+}

--- a/src/app/(common)/privacyPolicy/page.tsx
+++ b/src/app/(common)/privacyPolicy/page.tsx
@@ -1,0 +1,3 @@
+export default function PrivacyPolicy() {
+  return <div>プライバシーポリシー</div>;
+}

--- a/src/app/(common)/privacyPolicy/page.tsx
+++ b/src/app/(common)/privacyPolicy/page.tsx
@@ -1,3 +1,14 @@
 export default function PrivacyPolicy() {
-  return <div>プライバシーポリシー</div>;
+  return (
+    <div>
+      <div className="absolute left-1/2 top-4 z-10 mt-2 -translate-x-1/2 text-4xl font-bold text-white">
+        <p
+          className="mt-2 min-w-[300px] rounded-md bg-black/50 p-4 text-center text-2xl sm:mb-2 sm:text-2xl md:text-5xl"
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          プライバシーポリシー
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/src/app/(common)/termOfService/page.tsx
+++ b/src/app/(common)/termOfService/page.tsx
@@ -1,0 +1,3 @@
+export default function TermOfService() {
+  return <div>利用規約</div>;
+}

--- a/src/app/(common)/termOfService/page.tsx
+++ b/src/app/(common)/termOfService/page.tsx
@@ -1,3 +1,14 @@
 export default function TermOfService() {
-  return <div>利用規約</div>;
+  return (
+    <div>
+      <div className="absolute left-1/2 top-4 z-10 mt-2 -translate-x-1/2 text-4xl font-bold text-white">
+        <p
+          className="mt-2 min-w-[300px] rounded-md bg-black/50 p-4 text-center text-2xl sm:mb-2 sm:text-2xl md:text-5xl"
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          利用規約
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/src/components/layouts/footers/index.tsx
+++ b/src/components/layouts/footers/index.tsx
@@ -51,21 +51,21 @@ export default function Footer() {
           }}
         >
           <Link
-            href="#"
+            href="privacyPolicy"
             underline="hover"
             sx={{ color: 'white', '&:hover': { color: 'gray' } }}
           >
             プライバシーポリシー
           </Link>
           <Link
-            href="#"
+            href="termOfService"
             underline="hover"
             sx={{ color: 'white', '&:hover': { color: 'gray' } }}
           >
             利用規約
           </Link>
           <Link
-            href="#"
+            href="contact"
             underline="hover"
             sx={{ color: 'white', '&:hover': { color: 'gray' } }}
           >
@@ -75,7 +75,10 @@ export default function Footer() {
         {/* ソーシャルメディアアイコン */}
         <Box className="flex space-x-4">
           {/* GitHubアイコン */}
-          <Link href="https://github.com/miura-taiga/dust-hunters" color="inherit">
+          <Link
+            href="https://github.com/miura-taiga/dust-hunters"
+            color="inherit"
+          >
             <GitHub
               fontSize="large"
               className="text-white transition-opacity hover:scale-110 hover:text-gray-400 hover:opacity-40"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,10 @@ export interface AuthLayoutProps {
   children: ReactNode;
 }
 
+export interface CommonLayoutProps {
+  children: ReactNode;
+}
+
 export interface GuildCardsLayoutProps {
   children: ReactNode;
 }


### PR DESCRIPTION
## 概要

(common)ディレクトリは配下の`プライバシーポリシー`,`利用規約`,`お問い合わせ`の各ページを作成し、`<Footers />コンポーネントから各ページへ画面遷移できる様にしました。

## 変更内容

- `contact`,`termOfService`,`privacyPolicy`のページファイル作成
- `src/app/(common)/layout.tsx`にてレイアウトの作成
- `src/components/layouts/footers/index.tsx`にて各ページへの遷移先を指定

## 動作確認

- [x] <Footers />から各ページへ画面が遷移できること

[![Image from Gyazo](https://i.gyazo.com/e384e9ab13d407e72243234cf5df6598.gif)](https://gyazo.com/e384e9ab13d407e72243234cf5df6598)