### PR TITLE
fix/ギルドカードのデータの取得方法

### DIFF
--- a/src/app/(auth)/guildCards/cleanAreaGraph/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/cleanAreaGraph/[uid]/page.tsx
@@ -75,7 +75,8 @@ export default function CleanAreaGraph() {
     }
 
     if (Array.isArray(defeatedData)) {
-      const counts = defeatedData.map((record) => record.defeat_count);
+      const sortedData = defeatedData.sort((a, b) => a.quest_id - b.quest_id);
+      const counts = sortedData.map((record) => record.defeat_count);
       setDefeatCount(counts);
       setIsLoading(false);
     }

--- a/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
@@ -29,14 +29,16 @@ export default function MonsterEncyclopedia() {
 
   useEffect(() => {
     if (Array.isArray(monstersData)) {
-      const formattedGuildCards = monstersData.map((data) => ({
-        defeat_count: data.defeat_count,
-        monster: {
-          id: data.monster_id,
-          name: data.monster_name,
-          bestiary_monster_image_url: data.bestiary_monster_image_url,
-        } as Monster,
-      }));
+      const formattedGuildCards = monstersData
+        .map((data) => ({
+          defeat_count: data.defeat_count,
+          monster: {
+            id: data.monster_id,
+            name: data.monster_name,
+            bestiary_monster_image_url: data.bestiary_monster_image_url,
+          } as Monster,
+        }))
+        .sort((a, b) => a.monster.id - b.monster.id);
 
       setGuildCards(formattedGuildCards);
     }


### PR DESCRIPTION
## 概要

図鑑ページと掃除場所ページで一部本番環境のみレイアウトが異なる表記になっていたので、データの取得方法を見直し、レイアウトの乱れを修正しました。

## 変更内容

- `src/app/(auth)/guildCards/cleanAreaGraph/[uid]/page.tsx`にて`monstersData`をソートしてから`setGuildCards`に設定
- `src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx`にて`quest_id`に基づいてデータを昇順にソートする処理を追加