### PR TITLE
guildCardsTabのレイアウト修正

### DIFF
--- a/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/encyclopedias/[uid]/page.tsx
@@ -46,7 +46,7 @@ export default function MonsterEncyclopedia() {
 
   return (
     <div className="relative min-h-screen overflow-hidden">
-      <div className="absolute left-1/2 top-6 z-10 -translate-x-1/2 text-4xl font-bold text-white">
+      <div className="absolute left-1/2 top-16 z-10 mt-2 -translate-x-1/2 text-4xl font-bold text-white">
         <p
           className="mt-2 min-w-[300px] rounded-md bg-black/50 p-4 text-center text-2xl sm:mb-2 sm:text-2xl md:text-5xl"
           style={{ whiteSpace: 'nowrap' }}
@@ -64,7 +64,7 @@ export default function MonsterEncyclopedia() {
           paddingBottom: '80px',
         }}
       >
-        <Grid container spacing={8} sx={{ marginTop: '76px' }}>
+        <Grid container spacing={8} sx={{ marginTop: '94px' }}>
           {guildCards.map((guildCard) => (
             <Grid item xs={12} sm={6} md={4} lg={3} key={guildCard.monster.id}>
               <StyledCard className="mx-auto h-full max-w-[300px] rounded-xl border-4 border-gray-300 p-4 text-white shadow-lg">

--- a/src/components/layouts/guildCardsTab/index.tsx
+++ b/src/components/layouts/guildCardsTab/index.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import BookIcon from '@mui/icons-material/Book';
+import HistoryIcon from '@mui/icons-material/History';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
 import Box from '@mui/material/Box';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
@@ -43,6 +46,7 @@ const CustomTabs: React.FC = () => {
           right: 0,
           zIndex: 1000,
           backgroundColor: 'white',
+          height: '64px',
         }}
       >
         <Tabs
@@ -51,13 +55,53 @@ const CustomTabs: React.FC = () => {
           aria-label="navigation tabs"
           variant="fullWidth"
           className="rounded-md shadow-md"
+          TabIndicatorProps={{
+            style: {
+              height: '4px',
+            },
+          }}
         >
-          <Tab label="図鑑" className="font-medium text-gray-800" />
-          <Tab label="活動履歴" className="font-medium text-gray-800" />
-          <Tab label="掃除場所" className="font-medium text-gray-800" />
+          <Tab
+            icon={<BookIcon />}
+            iconPosition="start"
+            label="図鑑"
+            className="font-semibold text-gray-500 lg:text-lg lg:font-bold"
+            sx={{
+              paddingY: { xs: '8px', lg: '16px' },
+              fontSize: { xs: '12px', sm: '14px', lg: '16px' },
+              '& .MuiTab-wrapper': {
+                whiteSpace: 'nowrap',
+              },
+            }}
+          />
+          <Tab
+            icon={<HistoryIcon />}
+            iconPosition="start"
+            label="活動履歴"
+            className="font-semibold text-gray-500 lg:text-lg lg:font-bold"
+            sx={{
+              paddingY: { xs: '8px', lg: '16px' },
+              fontSize: { xs: '12px', sm: '14px', lg: '16px' },
+              '& .MuiTab-wrapper': {
+                whiteSpace: 'nowrap',
+              },
+            }}
+          />
+          <Tab
+            icon={<LocationOnIcon />}
+            iconPosition="start"
+            label="掃除場所"
+            className="font-semibold text-gray-500 lg:text-lg lg:font-bold"
+            sx={{
+              paddingY: { xs: '8px', lg: '16px' },
+              fontSize: { xs: '12px', sm: '14px', lg: '16px' },
+              '& .MuiTab-wrapper': {
+                whiteSpace: 'nowrap',
+              },
+            }}
+          />
         </Tabs>
       </Box>
-      <div style={{ paddingTop: '48px' }}></div>
     </div>
   );
 };


### PR DESCRIPTION
## 概要

現状のguildCardsTabのレイアウトだと、PC画面の際に存在感が薄かったのでレイアウトの見直しを行いました。

## 変更内容

- iconの追加
- タブの高さを調整
- フォントカラーの調整
- レイアウト変更に伴う図鑑ページのレイアウト修正

## 動作確認

- [x] レスポンシブ対応がなされ、上部タブの存在感が増していること

| 変更前 | 変更後 |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/c378331020c5901674438c0bdb4aec09.jpg)](https://gyazo.com/c378331020c5901674438c0bdb4aec09) | [![Image from Gyazo](https://i.gyazo.com/caca44fd11c1a9324e83dda96fd07a53.jpg)](https://gyazo.com/caca44fd11c1a9324e83dda96fd07a53) |