### PR TITLE
bugfix/ defeatedDataがない場合の表示方法を修正

### DIFF
--- a/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
@@ -52,9 +52,10 @@ export default function DailyHuntLog() {
 
     const logData = monthDays.map((date) => {
       const dateString = format(date, 'yyyy-MM-dd');
-      const defeated = defeatedData?.defeated_at?.some((record) =>
-        record.startsWith(dateString)
-      ) || false;
+      const defeated =
+        defeatedData?.defeated_at?.some((record) =>
+          record.startsWith(dateString),
+        ) || false;
       return { date: dateString, defeated };
     });
 

--- a/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
+++ b/src/app/(auth)/guildCards/dailyHuntLog/[uid]/page.tsx
@@ -43,10 +43,6 @@ export default function DailyHuntLog() {
   );
 
   useEffect(() => {
-    if (!defeatedData || !Array.isArray(defeatedData.defeated_at)) {
-      return;
-    }
-
     const start = startOfMonth(currentMonth);
     const end = endOfMonth(currentMonth);
     const monthDays = eachDayOfInterval({ start, end });
@@ -56,9 +52,9 @@ export default function DailyHuntLog() {
 
     const logData = monthDays.map((date) => {
       const dateString = format(date, 'yyyy-MM-dd');
-      const defeated = defeatedData.defeated_at.some((record) =>
-        record.startsWith(dateString),
-      );
+      const defeated = defeatedData?.defeated_at?.some((record) =>
+        record.startsWith(dateString)
+      ) || false;
       return { date: dateString, defeated };
     });
 


### PR DESCRIPTION
## 概要

`defeatedData`がない場合Loading画面が表示されていた箇所をない場合でも空で表示するように変更しました。

## 変更内容

1. 条件チェックを削除し、常にカレンダーを表示するように変更
```
if (!defeatedData || !Array.isArray(defeatedData.defeated_at)) {
      return;
    }
``` 

2. defeatedの判定時に`defeatedData`の存在をチェックを追加し、ない場合は`false`を返すよう変更
```
const defeated =
        defeatedData?.defeated_at?.some((record) =>
          record.startsWith(dateString),
        ) || false;
```

## 動作確認

- [x] `defeatedData`がない場合でもカレンダーの表示ができている

| 変更前 | 変更後 |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/e23f7e655f3d50a9e3a1660995a3741b.jpg)](https://gyazo.com/e23f7e655f3d50a9e3a1660995a3741b) | [![Image from Gyazo](https://i.gyazo.com/90c94e224e34897ce665619398c5a678.jpg)](https://gyazo.com/90c94e224e34897ce665619398c5a678) |